### PR TITLE
Check if index exists before performing a search

### DIFF
--- a/src/main/java/org/elasticsearch/module/WordDelimiterRunnable.java
+++ b/src/main/java/org/elasticsearch/module/WordDelimiterRunnable.java
@@ -52,7 +52,8 @@ public class WordDelimiterRunnable extends AbstractRunnable {
         logger.error(e.getMessage());
       }
 
-      client.search(searchRequest, listener);
+      if (client.admin().indices().prepareExists(index).get().isExists())
+        client.search(searchRequest, listener);
     }
   }
 }


### PR DESCRIPTION
This is an alternative to the index autocreation.
This approach will greatly simplify the code.

If we opted to create the index instead, we would need to wait for the
node to finish the initialization and for the cluster status to turn
green, before attempting the creation.
After creating the index, we would also need to wait for the shards to
come up before performing a search.
If the shards are in a POST_RECOVERY state at the time of the search,
an exception will be raised and there is nothing we can do to prevent
it (except for putting the thread to sleep for a X amount of time).

(the shard part has been fixed in the 2.x series
https://github.com/elastic/elasticsearch/pull/13246)